### PR TITLE
Some refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 lightning_logs/
 AL-Li/
-__pycache__/
 wandb/
 proxies/ic/li-ssb/
 oracles/apikey.txt
@@ -13,3 +12,169 @@ apikey.txt
 *.log
 *.out
 *.swp
+checkpoints/
+.vscode/
+.DS_Store
+
+# From https://github.com/github/gitignore/blob/main/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/config/mp20.py
+++ b/config/mp20.py
@@ -26,6 +26,7 @@ config = {
     "tune_var": "batch_size",
     "target": "formation_energy_per_atom",
     "epochs": 4,
+    "es_patience": 3,
 }
 
 # layer_search = [

--- a/config/mp20.py
+++ b/config/mp20.py
@@ -1,4 +1,5 @@
 import os.path as osp
+
 import torch
 
 base_config = {
@@ -6,8 +7,7 @@ base_config = {
     "input_len": 96,
     "hidden_layers": [512, 512],
     "lr": 1e-2,
-    # "lr": [1e-2, 1e-3, 1e-4, 1e-5],
-    "batch_size": [32, 64, 128, 256],
+    "batch_size": 32,
 }
 scalex = {
     "mean": torch.load(osp.join(base_config["root"], "x.mean")),
@@ -23,7 +23,9 @@ config = {
     "model_config": base_config,
     "xscale": scalex,
     "yscale": scaley,
-    "tune_var": "batch_size",
+    "model_grid_search": {
+        "batch_size": [32, 64, 128],
+    },
     "target": "formation_energy_per_atom",
     "epochs": 4,
     "es_patience": 3,

--- a/run.py
+++ b/run.py
@@ -1,18 +1,27 @@
 import copy
 import random
 
+import numpy as np
+import pytorch_lightning as pl
 import torch
 import torch.nn as nn
-import numpy as np
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
+from pytorch_lightning.loggers import WandbLogger
 from torch.nn.init import xavier_uniform_
 from torch.utils.data import DataLoader
-import pytorch_lightning as pl
-from pytorch_lightning.loggers import WandbLogger
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
+from config.mp20 import config
 from proxies.data import CrystalFeat
 from proxies.models import ProxyMLP, ProxyModel
-from config.mp20 import config
+from utils.callbacks import get_checkpoint_callback
+from utils.misc import (
+    flatten_grid_search,
+    get_run_dir,
+    merge_dicts,
+    print_config,
+    resolve,
+)
+from utils.parser import parse_args_to_dict
 
 SEED = 0
 torch.manual_seed(SEED)
@@ -78,19 +87,43 @@ def train(config, logger):
         logger.experiment.finish()
 
 
-def main(config):
-    model_config = copy.copy(config["model_config"])
-    tune_var = config["tune_var"]
-
-    for var in model_config[tune_var]:
-        config["model_config"][tune_var] = var
-        name = [
-            key + "-" + str(config["model_config"][key]) for key in ["lr", "batch_size"]
-        ]
-        # logger = None
-        logger = WandbLogger(project="Proxy-MP20", name="_".join(name))
-        train(config, logger=logger)
-
-
 if __name__ == "__main__":
-    main(config)
+    # parse command-line arguments as `--key=value` and merge with config
+    # allows for nested dictionaries: `--key.subkey=value``
+    cli_conf = parse_args_to_dict()
+    config["run_dir"] = get_run_dir()
+    config = merge_dicts(config, cli_conf)
+    config["run_dir"] = resolve(config["run_dir"])
+    config["run_dir"].mkdir(parents=True, exist_ok=True)
+    config["run_dir"] = str(config["run_dir"])
+
+    print_config(config)
+
+    model_config = copy.copy(config["model_config"])
+    if config.get("model_grid_search"):
+        grid = flatten_grid_search(config["model_grid_search"])
+    else:
+        grid = [{}]
+
+    for m, model_grid_conf in enumerate(grid):
+        if len(grid) > 1:
+            print("\n" + "=" * 80)
+            print("=" * 80)
+            print_config(model_grid_conf)
+
+        config["model_config"] = merge_dicts(model_config, model_grid_conf)
+        name = "_".join(
+            [f"{key}-{config['model_config'][key]}" for key in ["lr", "batch_size"]]
+        )
+        # or "_".join([f"{k}-{v}" for k, v in model_grid_conf.items()])
+
+        if not config.get("no_logger"):
+            logger = WandbLogger(
+                project="Proxy-MP20",
+                name=(name),
+                entity="mila-ocp",
+            )
+        else:
+            logger = None
+
+        train(config, logger=logger)

--- a/run.py
+++ b/run.py
@@ -57,14 +57,16 @@ def train(config, logger):
     model.apply(weights_init)
     criterion = nn.MSELoss()
     accuracy = nn.L1Loss()
-    early = EarlyStopping(monitor="val_acc", patience=3, mode="max")
+    ckpt = get_checkpoint_callback(
+        config["run_dir"], logger, monitor="val_acc", mode="max"
+    )
 
     model = ProxyModel(model, criterion, accuracy, model_config["lr"])
     trainer = pl.Trainer(
         max_epochs=config["epochs"],
         logger=logger,
         log_every_n_steps=1,
-        callbacks=early,
+        callbacks=[ckpt, early],
         min_epochs=1,
     )
     trainer.fit(model=model, train_dataloaders=trainloader, val_dataloaders=valloader)

--- a/run.py
+++ b/run.py
@@ -57,6 +57,7 @@ def train(config, logger):
     model.apply(weights_init)
     criterion = nn.MSELoss()
     accuracy = nn.L1Loss()
+    early = EarlyStopping(monitor="val_acc", patience=config["es_patience"], mode="max")
     ckpt = get_checkpoint_callback(
         config["run_dir"], logger, monitor="val_acc", mode="max"
     )

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from typing import Optional, Union
+from uuid import uuid4
+
+from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
+from pytorch_lightning.loggers import Logger
+
+from .misc import resolve
+
+
+def get_checkpoint_callback(
+    run_dir: Union[Path, str],
+    logger: Optional[Logger] = None,
+    monitor: Optional[str] = "val_acc",
+    mode: Optional[str] = "max",
+) -> ModelCheckpoint:
+    """
+    Get a checkpoint callback to save model checkpoints.
+
+    If the logger is available and its id is not None, the checkpoints are saved in
+    ``run_dir / logger.id``
+
+    Otherwise a random ``uuid`` is used as the checkpoint directory name.
+
+    Returns:
+        ModelCheckpoint: The checkpoint callback.
+    """
+    dirpath = resolve(run_dir)
+    if logger and logger._id:
+        ckpt_dir = logger._id
+    else:
+        ckpt_dir = str(uuid4()).split("-")[0]
+
+    return ModelCheckpoint(
+        dirpath=dirpath / f"checkpoints-{ckpt_dir}",
+        filename="{epoch}-{step}" + f"-{{{monitor}}}" if monitor else "",
+        monitor=monitor,
+        mode=mode,
+        verbose=True,
+    )

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,0 +1,17 @@
+from os.path import expandvars
+from pathlib import Path
+
+
+def resolve(path: Union[str, Path]) -> Path:
+    """
+    Resolve a path to an absolute ``pathlib.Path``, expanding environment variables and
+    user home directory.
+
+    Args:
+        path: The path to resolve.
+
+    Returns:
+        The resolved path.
+    """
+    return Path(expandvars(path)).expanduser().resolve()
+

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,5 +1,14 @@
+import copy
+import os
+from itertools import product
 from os.path import expandvars
 from pathlib import Path
+from typing import Dict, List, Union
+from uuid import uuid4
+
+from yaml import dump
+
+JOB_ID = os.environ.get("SLURM_JOB_ID")
 
 
 def resolve(path: Union[str, Path]) -> Path:
@@ -15,3 +24,164 @@ def resolve(path: Union[str, Path]) -> Path:
     """
     return Path(expandvars(path)).expanduser().resolve()
 
+
+ROOT = resolve(__file__).parent.parent  # repo root Path
+
+
+def is_mila() -> bool:
+    """
+    Check if the code is running on the Mila cluster.
+
+    Returns:
+        bool: True if the code is running on the Mila cluster.
+    """
+    return resolve("~").parts[2] == "mila"
+
+
+def get_run_dir() -> Path:
+    """
+    Get the run directory.
+    On Mila, it is $SCRATCH/crystals-proxys/runs/SLURM_JOB_ID.
+    Otherwise, they are in a random sub-directory of checkpoints/
+
+    If the directory already exists, a new one is created with a suffix "-1", "-2", etc.
+
+    Example:
+    .. code-block:: python
+        d = get_run_dir()
+        d.mkdir()
+        print(d) # /home/mila/schmidtv/crystals-proxys/runs/3037262
+
+        d = get_run_dir()
+        d.mkdir()
+        print(d) # /home/mila/schmidtv/crystals-proxys/runs/3037262-1
+
+        d = get_run_dir()
+        d.mkdir()
+        print(d) # /home/mila/schmidtv/crystals-proxys/runs/3037262-2
+
+    Returns:
+        Path: new (unique) run dir for this execution
+    """
+    if is_mila() and JOB_ID is not None:
+        dirpath = resolve(f"$SCRATCH/crystals-proxys/runs/{JOB_ID}")
+    else:
+        u = str(uuid4()).split("-")[0]
+        dirpath = ROOT / "checkpoints" / u
+
+    if dirpath.exists():
+        i = (
+            max(
+                [
+                    float(p.name.split("-")[-1])
+                    for p in dirpath.parent.glob(f"{dirpath.name}-*")
+                ]
+            )
+            + 1
+        )
+        dirpath = dirpath.parent / f"{dirpath.name}-{int(i)}"
+    print("Run dir:", (dirpath))
+    return dirpath
+
+
+def print_config(config: dict) -> None:
+    """
+    Print a config dictionary to stdout.
+    Discard the "xscale" and "yscale" keys.
+
+    Args:
+        config (dict): config dictionary to print
+    """
+    config = copy.deepcopy(config)
+    config.pop("xscale", None)
+    config.pop("yscale", None)
+    print(dump(config))
+
+
+def flatten_grid_search(grid: Dict[str, List]) -> List[Dict]:
+    """
+    Creates the cartesian product of all the values in `grid`, and returns a list of
+    dictionaries.
+
+    Example:
+
+    .. code-block:: python
+        >>> flatten_grid_search({"a": [1, 2], "b": [3, 4]})
+        [{"a": 1, "b": 3}, {"a": 1, "b": 4}, {"a": 2, "b": 3}, {"a": 2, "b": 4}]
+
+    Args:
+        grid (Dict[str, List]): The grid's parameterization
+
+    Returns:
+        List[Dict]: List of all HP combinations
+    """
+    keys = list(grid.keys())
+    values = list(grid.values())
+    return [dict(zip(keys, v)) for v in product(*values)]
+
+
+def merge_dicts(dict1: dict, dict2: dict) -> dict:
+    """Recursively merge two dictionaries.
+    Values in dict2 override values in dict1. If dict1 and dict2 contain a dictionary
+    as a value, this will call itself recursively to merge these dictionaries.
+    This does not modify the input dictionaries (creates an internal copy).
+    Additionally returns a list of detected duplicates.
+    Adapted from https://github.com/TUM-DAML/seml/blob/master/seml/utils.py
+
+    Example:
+
+    .. code-block:: python
+        >>> merge_dicts({"a": 1, "b": 2, "c": {"d": 3}}, {"b": 3, "c": {"d": 4}})
+        {"a": 1, "b": 3, "c": {"d": 4}}
+
+    Parameters
+    ----------
+    dict1: dict
+        First dict.
+    dict2: dict
+        Second dict. Values in dict2 will override values from dict1 in case they share
+        the same key.
+
+    Returns
+    -------
+    return_dict: dict
+        Merged dictionaries.
+    """
+    if not isinstance(dict1, dict):
+        raise ValueError(f"Expecting dict1 to be dict, found {type(dict1)} {dict1}.")
+    if not isinstance(dict2, dict):
+        raise ValueError(f"Expecting dict2 to be dict, found {type(dict2)} {dict2}.")
+
+    return_dict = copy.deepcopy(dict1)
+
+    for k, v in dict2.items():
+        if k not in dict1:
+            return_dict[k] = v
+        else:
+            if isinstance(v, dict) and isinstance(dict1[k], dict):
+                return_dict[k] = merge_dicts(dict1[k], dict2[k])
+            elif isinstance(v, list) and isinstance(dict1[k], list):
+                if len(dict1[k]) != len(dict2[k]):
+                    raise ValueError(
+                        f"List for key {k} has different length in dict1 and dict2."
+                        + " Use an empty dict {} to pad for items in the shorter list."
+                    )
+                if isinstance(dict1[k][0], dict):
+                    if not isinstance(dict2[k][0], dict):
+                        raise ValueError(
+                            f"Expecting dict for key {k} in dict2. ({dict1}, {dict2})"
+                        )
+                    return_dict[k] = [
+                        merge_dicts(d1, d2) for d1, d2 in zip(dict1[k], v)
+                    ]
+                else:
+                    if isinstance(dict2[k][0], dict):
+                        raise ValueError(
+                            f"Expecting dict for key {k} in dict1. ({dict1}, {dict2})"
+                        )
+                    return_dict[k] = v
+
+            else:
+                return_dict[k] = dict2[k]
+
+    return return_dict

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -1,0 +1,54 @@
+from argparse import ArgumentParser
+import ast
+
+
+def parse_value(value):
+    """
+    Parse string as Python literal if possible and fallback to string.
+    """
+    try:
+        if value.lower() == "true":
+            return True
+        elif value.lower() == "false":
+            return False
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        # Use as string if nothing else worked
+        return value
+
+
+def dict_set_recursively(dictionary, key_sequence, val):
+    top_key = key_sequence.pop(0)
+    if len(key_sequence) == 0:
+        dictionary[top_key] = val
+    else:
+        if top_key not in dictionary:
+            dictionary[top_key] = {}
+        dict_set_recursively(dictionary[top_key], key_sequence, val)
+
+
+def create_dict_from_args(args: list, sep: str = "."):
+    """
+    Create a (nested) dictionary from console arguments.
+    Keys in different dictionary levels are separated by sep.
+    """
+    return_dict = {}
+    for arg in args:
+        arg = arg.strip("--")
+        keys_concat, val = arg.split("=") if "=" in arg else (arg, "True")
+        val = parse_value(val)
+        key_sequence = keys_concat.split(sep)
+        dict_set_recursively(return_dict, key_sequence, val)
+    return return_dict
+
+
+def parse_args_to_dict() -> dict:
+    """
+    Parse arbitrary command line arguments to a dictionary.
+
+        Returns:
+            dict: _description_
+    """
+    parser = ArgumentParser()
+    _, override_args = parser.parse_known_args()
+    return create_dict_from_args(override_args)


### PR DESCRIPTION
Refactored a small number of things:

* arbitrary config overwrite from the command-line
* `tune_var` is gone, it's all in a `model_grid_search` config key (to discuss later, I want this PR to be minimally disruptive)
* Checkpoints are saved in
	* `checkpoints/` if running locally
	* `$SCRATCH/crystals-proxy/runs/$SLURM_JOB_ID` otherwise
		* If there are multiple training loops in this script (grid search) each of them has its own nested checkpoints directory (see prints)
		* If the script is run multiple times in the same job, the run_dir is changed to `$SCRATCH/crystals-proxy/runs/$SLURM_JOB_ID-1` (then `$SCRATCH/crystals-proxy/runs/$SLURM_JOB_ID-2` etc.) in order to minimize conflicts
* `black`
* Imports sorting
* Deactivate logging from the command-line with `--no_logger` (useful when debugging)