### PR TITLE
Fix `CrystalFeat` data set to handle Matbench v4 processing

### DIFF
--- a/config/tasks/mbform.yaml
+++ b/config/tasks/mbform.yaml
@@ -1,5 +1,5 @@
-root: /network/scratch/s/schmidtv/crystals-proxys/data/materials_dataset_v3/data/
-src: $root/matbench_mp_e_form
+root: /network/projects/crystalgfn/data/materials_dataset_v4/
+src: $root/data/matbench_mp_e_form
 target: Eform
 scales:
   x:

--- a/config/tasks/mbgap.yaml
+++ b/config/tasks/mbgap.yaml
@@ -1,5 +1,5 @@
-root: /network/scratch/s/schmidtv/crystals-proxys/data/materials_dataset_v3/data/
-src: $root/matbench_mp_gap/
+root: /network/projects/crystalgfn/data/materials_dataset_v4/
+src: $root/data/matbench_mp_gap/
 target: Band Gap
 scales:
   x:

--- a/dave/proxies/data.py
+++ b/dave/proxies/data.py
@@ -81,7 +81,9 @@ class CrystalFeat(Dataset):
 
         # To directly handle missing atomic numbers
         # missing_atoms = torch.zeros(x.shape[0], 5)
-        # self.composition = torch.cat((x[:, 8:92].to(torch.int32), missing_atoms, x[:, 92:]), dim=-1)
+        # self.composition = torch.cat(
+        #   (x[:, 8:92].to(torch.int32), missing_atoms, x[:, 92:]), dim=-1
+        # )
 
     def __len__(self):
         return self.sg.shape[0]
@@ -165,25 +167,19 @@ class CrystalGraph(InMemoryDataset):
         if self.name == "mp20":
             from dave.utils.cdvae_csv import write_data_csv
 
-            download_url(
-                f"https://raw.githubusercontent.com/txie-93/cdvae/main/data/mp_20/train.csv",
-                temp_raw,
-            )
-            download_url(
-                f"https://raw.githubusercontent.com/txie-93/cdvae/main/data/mp_20/val.csv",
-                temp_raw,
-            )
-            download_url(
-                f"https://raw.githubusercontent.com/txie-93/cdvae/main/data/mp_20/test.csv",
-                temp_raw,
-            )
+            base_url = "https://raw.githubusercontent.com/txie-93/cdvae/main/data/mp_20"
+            download_url(f"{base_url}/train.csv", temp_raw)
+            download_url(f"{base_url}/val.csv", temp_raw)
+            download_url(f"{base_url}/test.csv", temp_raw)
             write_data_csv(self.raw_dir)
+
         if self.name == "matbench_mp_e_form":
             from dave.utils.mb_data_process import base_split, base_write_dataset_csv
 
             json_file = raw_parent / "matbench_mp_e_form.json"
             if not json_file.is_file():
-                json_url = "https://ml.materialsproject.org/projects/matbench_mp_e_form.json.gz"
+                base_url = "https://ml.materialsproject.org/projects"
+                json_url = f"{base_url}/matbench_mp_e_form.json.gz"
                 print("Downloading from " + json_url)
                 with open(str(json_file), "wb") as j:
                     r = requests.get(json_url)
@@ -297,12 +293,12 @@ class CrystalGraph(InMemoryDataset):
             datapoint.energy = data.y
             datapoint.struct = [data.struct]
             datapoint.lp = data.lp.unsqueeze(0)
-        
+
         if data.natoms != datapoint.natoms:
             print("Warning: natoms mismatch")
         # if not (data.atomic_numbers == datapoint.atomic_numbers).all():
         #     print("Warning: atomic_numbers mismatch")
-        
+
         # Consider a single pyxtal sample for now
         data = pyxtal_data_list[0]  # TODO
         return data

--- a/dave/proxies/data.py
+++ b/dave/proxies/data.py
@@ -1,10 +1,6 @@
 import gzip
-import os
 import os.path as osp
-import sys
-import tempfile
 from pathlib import Path
-from typing import Any, Callable, List, Sequence
 
 import numpy as np
 import pandas as pd
@@ -12,23 +8,19 @@ import requests
 import torch
 from faenet.transforms import FrameAveraging
 from mendeleev.fetch import fetch_table
+from pymatgen.core import Composition
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pyxtal import pyxtal
-from pyxtal.lattice import Lattice
-from torch.utils.data import DataLoader, Dataset
-from torch_geometric.data import Data, InMemoryDataset, download_url
-from torch_geometric.loader import DataLoader as GraphLoader
+from torch.utils.data import Dataset
+from torch_geometric.data import InMemoryDataset, download_url
 from tqdm import tqdm
 
 from dave.utils.atoms_to_graph import (
-    collate,
     compute_neighbors,
     make_a2g,
     pymatgen_struct_to_pyxtal_to_graphs,
     pymatgen_structure_to_graph,
 )
-
 
 
 def composition_df_to_z_tensor(comp_df, max_z=-1):


### PR DESCRIPTION
The `v4` data sets stored in `/network/projects/crystalgfn/data/materials_dataset_v4` contains a `"Formulae"` column instead of elements as columns so I added a new `formulae_to_z_tensor` function that is automatically called if the `CSV` data contains a `"Formulae"` column.